### PR TITLE
ci: add publish-image workflow

### DIFF
--- a/.github/containerscan/allowedlist.yaml
+++ b/.github/containerscan/allowedlist.yaml
@@ -1,0 +1,6 @@
+---
+general:
+  vulnerabilities:
+    # libretls vulnerability in alpine:3.15.1, currently there is no newer
+    # alpine tag.
+    - CVE-2022-0778

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -1,0 +1,56 @@
+---
+name: publish-image
+on:   
+  push:
+    # Publish `main` as Docker `latest` image.
+    branches:
+      - main
+    # Publish `v1.2.3` tags as releases.
+    tags:
+      - v*
+  # Publish PR images.
+  pull_request:
+
+env:
+  IMAGE_NAME: pod-image-swap-webhook
+  PR_NUMBER: ${{ github.event.number }}
+
+jobs:
+  publish-image:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build image
+        run: docker build -f Dockerfile -t $IMAGE_NAME .
+
+      - name: Login to ghcr.io
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Push image
+        run: |
+          IMAGE_ID=ghcr.io/${{ github.repository_owner }}/$IMAGE_NAME
+
+          # Change all uppercase to lowercase
+          IMAGE_ID=$(echo $IMAGE_ID | tr '[A-Z]' '[a-z]')
+
+          # Strip git ref prefix from version
+          VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
+
+          # Use Docker `latest` tag convention or `pr-{number}` for pull
+          # requests
+          if [ "$VERSION" == "main" ]; then
+            VERSION=latest
+          elif [ -n "$PR_NUMBER" ]; then
+            VERSION="pr-${PR_NUMBER}"
+          fi
+
+          echo IMAGE_ID=$IMAGE_ID
+          echo VERSION=$VERSION
+
+          docker tag $IMAGE_NAME $IMAGE_ID:$VERSION
+          docker push $IMAGE_ID:$VERSION

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Scan image
         uses: azure/container-scan@v0
         with:
-          image-name: $IMAGE_NAME
+          image-name: ${{ env.IMAGE_NAME }}
 
       - name: Login to ghcr.io
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin

--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -28,6 +28,11 @@ jobs:
       - name: Build image
         run: docker build -f Dockerfile -t $IMAGE_NAME .
 
+      - name: Scan image
+        uses: azure/container-scan@v0
+        with:
+          image-name: $IMAGE_NAME
+
       - name: Login to ghcr.io
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN make build
 
 FROM alpine:3.15
 
-RUN apk update && apk add ca-certificates && rm -rf /var/cache/apk/*
+RUN apk --update --no-cache add ca-certificates
 
 COPY --from=builder /src/pod-image-swap-webhook /pod-image-swap-webhook
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,4 +23,6 @@ RUN apk --update --no-cache add ca-certificates
 
 COPY --from=builder /src/pod-image-swap-webhook /pod-image-swap-webhook
 
+USER nobody
+
 ENTRYPOINT ["/pod-image-swap-webhook"]


### PR DESCRIPTION
This PR adds an action that will publish the `ghcr.io/bonial-international-gmbh/pod-image-swap-webhook` docker image.

The following tags are published automatically:

- `latest` on push to the `main` branch
- `v${VERSION}` when a `v*` tag is pushed
- `pr-${PR_NUMBER}` when a PR is created/updated


Here is the link to the image that resulted from this PR: https://github.com/Bonial-International-GmbH/pod-image-swap-webhook/pkgs/container/pod-image-swap-webhook/17399805?tag=pr-2