### PR TITLE
feat: add helm chart

### DIFF
--- a/.github/workflows/release-charts.yml
+++ b/.github/workflows/release-charts.yml
@@ -1,0 +1,37 @@
+---
+name: release-charts
+on:
+  push:
+    # Release changed helm charts from `charts/` whenever a
+    # merge/push into `main` occurs.
+    #
+    # The packaged charts are stored in the `gh-pages` branch, the helm
+    # repository is served via GitHub Pages.
+    #
+    # See: https://github.com/helm/chart-releaser-action
+    branches:
+      - main
+
+jobs:
+  release-charts:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+
+      - name: Install Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.7.1
+
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.3.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/certs
 /config.yaml
 /coverage.txt
 /pod-image-swap-webhook
+/values.yaml

--- a/README.md
+++ b/README.md
@@ -6,7 +6,48 @@ A mutating webhook that patches Pod container images based on configuration
 rules. For example, if you want to transparently proxy image pulls through an
 internal registry, this webhook might be for you.
 
-**Note**: This project is currently WIP and the documentation is incomplete.
+## Preparation
+
+This webhook works best in combination with
+[Harbor](https://github.com/goharbor/harbor) and its [proxy
+cache](https://goharbor.io/docs/2.1.0/administration/configure-proxy-cache/)
+feature.
+
+It is recommended to setup a proxy cache project for every registry for which
+you want the webhook to replace images.
+
+Of course this webhook also works without Harbor.
+
+## Deployment
+
+The helm chart provided in this repository can be used to deploy the webhook.
+
+Create a `values.yaml` and add a `webhookConfig` section with the desired
+replacement configuration, for example:
+
+```yaml
+---
+webhookConfig:
+  exclude:
+    - prefix: k8s.gcr.io/ingress-nginx/controller
+  replace:
+    - prefix: quay.io
+      replacement: registry.example.org/quay.io
+    - prefix: k8s.gcr.io
+      replacement: registry.example.org/k8s.gcr.io
+    - prefix: docker.io
+      replacement: registry.example.org/docker.io
+```
+
+You can find documentation for all available configuration fields in
+[`config.sample.yaml`](config.sample.yaml).
+
+Finally use helm to install the webhook:
+
+```sh
+helm upgrade pod-image-swap-webhook charts/pod-image-swap-webhook \
+  --install --namespace kube-system --values values.yaml
+```
 
 ## License
 

--- a/charts/pod-image-swap-webhook/.helmignore
+++ b/charts/pod-image-swap-webhook/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/pod-image-swap-webhook/Chart.yaml
+++ b/charts/pod-image-swap-webhook/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: pod-image-swap-webhook
+description: A webhook that replaces Pod images based on configuration values
+type: application
+version: 0.0.1
+appVersion: "v0.0.1"

--- a/charts/pod-image-swap-webhook/templates/_helpers.tpl
+++ b/charts/pod-image-swap-webhook/templates/_helpers.tpl
@@ -1,0 +1,62 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "pod-image-swap-webhook.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "pod-image-swap-webhook.fullname" -}}
+{{- if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "pod-image-swap-webhook.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "pod-image-swap-webhook.labels" -}}
+helm.sh/chart: {{ include "pod-image-swap-webhook.chart" . }}
+{{ include "pod-image-swap-webhook.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "pod-image-swap-webhook.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "pod-image-swap-webhook.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "pod-image-swap-webhook.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "pod-image-swap-webhook.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/pod-image-swap-webhook/templates/configmap.yaml
+++ b/charts/pod-image-swap-webhook/templates/configmap.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "pod-image-swap-webhook.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "pod-image-swap-webhook.labels" . | nindent 4 }}
+data:
+  config.yaml: |
+    {{- toYaml .Values.webhookConfig | nindent 4 }}

--- a/charts/pod-image-swap-webhook/templates/deployment.yaml
+++ b/charts/pod-image-swap-webhook/templates/deployment.yaml
@@ -1,0 +1,92 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "pod-image-swap-webhook.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "pod-image-swap-webhook.labels" . | nindent 4 }}
+spec:
+  {{- if not .Values.hpa.create }}
+  replicas: {{ .Values.replicaCount }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "pod-image-swap-webhook.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        # Revision forces recreation of pods on upgrade.
+        # Required to refresh the server certificate and key.
+        revision: {{ .Release.Revision | quote }}
+        {{- include "pod-image-swap-webhook.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "pod-image-swap-webhook.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            - name: PISW_CONFIG_PATH
+              value: /config/config.yaml
+            - name: PISW_CERT_DIR
+              value: /certs
+          ports:
+            - name: metrics
+              containerPort: 8080
+              protocol: TCP
+            - name: healthz
+              containerPort: 8081
+              protocol: TCP
+            - name: webhook
+              containerPort: 9443
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: healthz
+          readinessProbe:
+            httpGet:
+              path: /readyz
+              port: healthz
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: config
+              mountPath: /config/config.yaml
+              subPath: config.yaml
+            - name: certs
+              mountPath: /certs
+      volumes:
+        - configMap:
+            name: {{ include "pod-image-swap-webhook.fullname" . }}
+          name: config
+        - secret:
+            secretName: {{ include "pod-image-swap-webhook.fullname" . }}
+          name: certs
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/pod-image-swap-webhook/templates/hpa.yaml
+++ b/charts/pod-image-swap-webhook/templates/hpa.yaml
@@ -1,0 +1,29 @@
+{{- if .Values.hpa.create }}
+apiVersion: autoscaling/v2beta1
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "pod-image-swap-webhook.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "pod-image-swap-webhook.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: {{ include "pod-image-swap-webhook.fullname" . }}
+  minReplicas: {{ .Values.hpa.minReplicas }}
+  maxReplicas: {{ .Values.hpa.maxReplicas }}
+  metrics:
+    {{- if .Values.hpa.targetCPUUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: cpu
+        targetAverageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+    {{- end }}
+    {{- if .Values.hpa.targetMemoryUtilizationPercentage }}
+    - type: Resource
+      resource:
+        name: memory
+        targetAverageUtilization: {{ .Values.hpa.targetMemoryUtilizationPercentage }}
+    {{- end }}
+{{- end }}

--- a/charts/pod-image-swap-webhook/templates/pdb.yaml
+++ b/charts/pod-image-swap-webhook/templates/pdb.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.podDisruptionBudget.create -}}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "pod-image-swap-webhook.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "pod-image-swap-webhook.labels" . | nindent 4 }}
+spec:
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  selector:
+    matchLabels:
+      {{- include "pod-image-swap-webhook.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/pod-image-swap-webhook/templates/service.yaml
+++ b/charts/pod-image-swap-webhook/templates/service.yaml
@@ -1,0 +1,20 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "pod-image-swap-webhook.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "pod-image-swap-webhook.labels" . | nindent 4 }}
+spec:
+  type: ClusterIP
+  ports:
+    - port: 443
+      targetPort: webhook
+      protocol: TCP
+      name: webhook
+    - port: 8080
+      targetPort: metrics
+      protocol: TCP
+      name: metrics
+  selector:
+    {{- include "pod-image-swap-webhook.selectorLabels" . | nindent 4 }}

--- a/charts/pod-image-swap-webhook/templates/serviceaccount.yaml
+++ b/charts/pod-image-swap-webhook/templates/serviceaccount.yaml
@@ -1,0 +1,13 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "pod-image-swap-webhook.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "pod-image-swap-webhook.labels" . | nindent 4 }}
+{{- end }}

--- a/charts/pod-image-swap-webhook/templates/webhook.yaml
+++ b/charts/pod-image-swap-webhook/templates/webhook.yaml
@@ -1,0 +1,52 @@
+{{- $altNames := list ( printf "%s.%s" (include "pod-image-swap-webhook.name" .) .Release.Namespace ) ( printf "%s.%s.svc" (include "pod-image-swap-webhook.name" .) .Release.Namespace ) -}}
+{{- $ca := genCA "pod-image-swap-webhook-ca" 3650 -}}
+{{- $cert := genSignedCert ( include "pod-image-swap-webhook.name" . ) nil $altNames 3650 $ca -}}
+{{- $caBundle := $cert.Cert | b64enc -}}
+{{- $privateKey := $cert.Key | b64enc }}
+
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/tls
+metadata:
+  name: {{ include "pod-image-swap-webhook.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "pod-image-swap-webhook.labels" . | nindent 4 }}
+data:
+  tls.crt: {{ $caBundle }}
+  tls.key: {{ $privateKey }}
+
+---
+apiVersion: admissionregistration.k8s.io/v1
+kind: MutatingWebhookConfiguration
+metadata:
+  name: {{ include "pod-image-swap-webhook.fullname" . }}
+  labels:
+    {{- include "pod-image-swap-webhook.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: post-install,post-upgrade
+webhooks:
+- admissionReviewVersions:
+    - v1
+  name: {{ printf "%s.%s.svc" (include "pod-image-swap-webhook.name" .) .Release.Namespace }}
+  failurePolicy: {{ .Values.webhook.failurePolicy }}
+  sideEffects: None
+  clientConfig:
+    caBundle: {{ $caBundle | quote }}
+    service:
+      name: {{ include "pod-image-swap-webhook.fullname" . }}
+      namespace: {{ .Release.Namespace }}
+      path: /mutate-v1-pod
+  rules:
+  - operations:
+    - CREATE
+    apiGroups:
+      - ""
+    apiVersions:
+      - v1
+    resources:
+      - pods
+{{- with .Values.webhook.namespaceSelector }}
+  namespaceSelector:
+    {{- toYaml . | nindent 4 }}
+{{- end }}

--- a/charts/pod-image-swap-webhook/templates/webhook.yaml
+++ b/charts/pod-image-swap-webhook/templates/webhook.yaml
@@ -23,8 +23,6 @@ metadata:
   name: {{ include "pod-image-swap-webhook.fullname" . }}
   labels:
     {{- include "pod-image-swap-webhook.labels" . | nindent 4 }}
-  annotations:
-    helm.sh/hook: post-install,post-upgrade
 webhooks:
 - admissionReviewVersions:
     - v1

--- a/charts/pod-image-swap-webhook/values.yaml
+++ b/charts/pod-image-swap-webhook/values.yaml
@@ -1,0 +1,90 @@
+# Default values for pod-image-swap-webhook.
+
+# Ignored if `hpa.create` is set to `true`.
+replicaCount: 2
+
+image:
+  repository: ghcr.io/bonial-international-gmbh/pod-image-swap-webhook
+  pullPolicy: IfNotPresent
+  # Overrides the image tag whose default is the chart appVersion.
+  tag: ""
+
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # Specifies whether a service account should be created.
+  create: true
+  # Annotations to add to the service account.
+  annotations: {}
+  # The name of the service account to use. If not set and create is true, a
+  # name is generated using the fullname template.
+  name: ""
+
+podAnnotations: {}
+
+podLabels: {}
+
+podSecurityContext:
+  fsGroup: 65534
+
+securityContext:
+  capabilities:
+    drop:
+    - ALL
+  readOnlyRootFilesystem: true
+  runAsNonRoot: true
+  runAsUser: 65534
+
+resources: {}
+  # limits:
+  #   memory: 20Mi
+  # requests:
+  #   cpu: 10m
+  #   memory: 20Mi
+
+hpa:
+  create: true
+  minReplicas: 2
+  maxReplicas: 6
+  targetCPUUtilizationPercentage: 80
+  # targetMemoryUtilizationPercentage: 80
+
+podDisruptionBudget:
+  create: true
+  minAvailable: 1
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}
+
+webhook:
+  failurePolicy: Ignore
+  # namespaceSelector: {}
+
+webhookConfig: {}
+  # # Exclusion rules: image prefixes that are not replaced. This is useful if you
+  # # want to replace all images from a whole registry, except for some specific
+  # # prefixes within this registry.
+  # exclude:
+  #   - prefix: k8s.gcr.io/ingress-nginx/controller
+  # # Replacement rules: these define an image prefix and a replacement for it.
+  # # Images from dockerhub are expanded to their fully qualified image name before
+  # # the rules are applied.
+  # #
+  # # For example:
+  # #
+  # # - the unnamespaced image `nginx:latest` gets expanded to
+  # #   `docker.io/library/nginx:latest`
+  # # - the namespaced image `goharbor/harbor-core:v2.4.2` gets expanded to
+  # #   `docker.io/goharbor/harbor-core:v2.4.2`
+  # replace:
+  #   - prefix: quay.io
+  #     replacement: registry.example.org/quay.io
+  #   - prefix: k8s.gcr.io
+  #     replacement: registry.example.org/k8s.gcr.io
+  #   - prefix: docker.io
+  #     replacement: registry.example.org/docker.io


### PR DESCRIPTION
This PR adds:

- the `pod-image-swap-webhook` helm chart
- the `release-charts` workflow to automatically publish chart updates to GitHub Pages which serves as a helm repository, using the chart-releaser-action: https://github.com/marketplace/actions/helm-chart-releaser

Notable details of the helm chart:
- the chart automatically generates a CA and TLS certificate/key on every release. The certificate is automatically injected into the webhook pods and the `MutatingWebhookConfiguration`. The CA and cert are valid for 10 years.
- actual configuration of replacement and exclusion rules happens via the `webhookConfig` key in the helm chart. The config is placed into a `ConfigMap` and injected into the webhook pods.
- `HorizontalPodAutoscaler`, `PodDisruptionBudget` and `ServiceAccount` are optional but enabled by default.

The usage of the helm chart from the GitHub Page helm repository will be documented in the README.md in a followup PR when the first version of the helm chart is released and usable.