### PR TITLE
fix: add config validation

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,6 +2,8 @@
 package config
 
 import (
+	"errors"
+	"fmt"
 	"os"
 
 	"gopkg.in/yaml.v2"
@@ -44,5 +46,48 @@ func Load(path string) (*Config, error) {
 		return nil, err
 	}
 
+	if err := config.Validate(); err != nil {
+		return nil, fmt.Errorf("config validation failed: %w", err)
+	}
+
 	return &config, nil
+}
+
+// Validate validates the configuration.
+func (c *Config) Validate() error {
+	for i, rule := range c.Exclude {
+		if err := rule.Validate(); err != nil {
+			return fmt.Errorf("invalid exclusion rule #%d: %w", i, err)
+		}
+	}
+
+	for i, rule := range c.Replace {
+		if err := rule.Validate(); err != nil {
+			return fmt.Errorf("invalid replacement rule #%d: %w", i, err)
+		}
+	}
+
+	return nil
+}
+
+// Validate validates the exclusion rule.
+func (r *ExclusionRule) Validate() error {
+	if r.Prefix == "" {
+		return errors.New("prefix must not be empty")
+	}
+
+	return nil
+}
+
+// Validate validates the replacement rule.
+func (r *ReplacementRule) Validate() error {
+	if r.Prefix == "" {
+		return errors.New("prefix must not be empty")
+	}
+
+	if r.Replacement == "" {
+		return errors.New("replacement must not be empty")
+	}
+
+	return nil
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,65 @@
+package config
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestConfig_Load(t *testing.T) {
+	t.Run("sample config is always valid", func(t *testing.T) {
+		cfg, err := Load("../../config.sample.yaml")
+		assert.NoError(t, err)
+		assert.Greater(t, len(cfg.Exclude), 0)
+		assert.Greater(t, len(cfg.Replace), 0)
+	})
+}
+
+func TestConfig_Validate(t *testing.T) {
+	t.Run("empty config is valid", func(t *testing.T) {
+		cfg := &Config{}
+		assert.NoError(t, cfg.Validate())
+	})
+
+	t.Run("valid config", func(t *testing.T) {
+		cfg := &Config{
+			Exclude: []ExclusionRule{
+				{Prefix: "someregistry.org/some-namespace"},
+			},
+			Replace: []ReplacementRule{
+				{
+					Prefix:      "someregistry.org",
+					Replacement: "otherregistry.org/someregistry.org",
+				},
+			},
+		}
+		assert.NoError(t, cfg.Validate())
+	})
+
+	t.Run("exclusion rule prefix must not be empty", func(t *testing.T) {
+		cfg := &Config{
+			Exclude: []ExclusionRule{
+				{Prefix: ""},
+			},
+		}
+		assert.Error(t, cfg.Validate())
+	})
+
+	t.Run("replacement rule prefix must not be empty", func(t *testing.T) {
+		cfg := &Config{
+			Replace: []ReplacementRule{
+				{Prefix: "", Replacement: "otherregistry.org/someregistry.org"},
+			},
+		}
+		assert.Error(t, cfg.Validate())
+	})
+
+	t.Run("replacement rule replacement must not be empty", func(t *testing.T) {
+		cfg := &Config{
+			Replace: []ReplacementRule{
+				{Prefix: "someregistry.org", Replacement: ""},
+			},
+		}
+		assert.Error(t, cfg.Validate())
+	})
+}


### PR DESCRIPTION
Adds validation to ensure that a loaded config is always valid. For now a config is valid if all fields are non-empty.

Apart from that there are no other requirements yet, but this may change in the future if more configuration options are added.

Tests were added to test the validation logic. In addition a test case was added to ensure that `config.sample.yaml` is always valid.