### PR TITLE
fix: do not publish docker images on PR

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -8,12 +8,9 @@ on:
     # Publish `v1.2.3` tags as releases.
     tags:
       - v*
-  # Publish PR images.
-  pull_request:
 
 env:
   IMAGE_NAME: pod-image-swap-webhook
-  PR_NUMBER: ${{ github.event.number }}
 
 jobs:
   publish-image:
@@ -46,12 +43,9 @@ jobs:
           # Strip git ref prefix from version
           VERSION=$(echo "${{ github.ref }}" | sed -e 's,.*/\(.*\),\1,')
 
-          # Use Docker `latest` tag convention or `pr-{number}` for pull
-          # requests
+          # Use Docker `latest` tag convention for `main` branch 
           if [ "$VERSION" == "main" ]; then
             VERSION=latest
-          elif [ -n "$PR_NUMBER" ]; then
-            VERSION="pr-${PR_NUMBER}"
           fi
 
           echo IMAGE_ID=$IMAGE_ID


### PR DESCRIPTION
We don't really need this and it has one problem: we do not have any
garbage collections for PR images.

They should only be around as long as the PR is not merged, but this
would require some cleanup logic. Better not produce them in the first
place for now.