### PR TITLE
chore: move catalog-info.yaml to repo root

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -7,7 +7,7 @@ metadata:
     A mutating webhook that patches Pod container images
     based on configuration rules.
   annotations:
-    backstage.io/techdocs-ref: dir:..
+    backstage.io/techdocs-ref: dir:.
   tags:
     - admission
     - go


### PR DESCRIPTION
We decided to go with the default location as this will avoid some
issues with the source location and relative plugin-specific links in
annotations.