### PR TITLE
fix: certain images were not correctly normalized

### DIFF
--- a/pkg/admission/handler.go
+++ b/pkg/admission/handler.go
@@ -110,14 +110,14 @@ func (h *PodImageHandler) patchContainer(container corev1.Container) corev1.Cont
 //   goharbor/harbor-core:v2.4.2 => docker.io/goharbor/harbor-core:v2.4.2
 func normalizeImage(image string) string {
 	parts := strings.Split(image, "/")
-	if strings.Contains(parts[0], ".") {
-		// Image starts with a registry domain, no normalization needed.
-		return image
-	}
-
 	if len(parts) == 1 {
 		// Image without namespace from dockerhub.
 		return fmt.Sprintf("docker.io/library/%s", parts[0])
+	}
+
+	if strings.Contains(parts[0], ".") {
+		// Image starts with a registry domain, no normalization needed.
+		return image
 	}
 
 	// Namespaced image from dockerhub.

--- a/pkg/admission/handler_test.go
+++ b/pkg/admission/handler_test.go
@@ -104,4 +104,5 @@ func TestNormalizeImage(t *testing.T) {
 	assert.Equal(t, "docker.io/goharbor/harbor-core:v2.4.2", normalizeImage("goharbor/harbor-core:v2.4.2"))
 	assert.Equal(t, "docker.io/goharbor/harbor-core:v2.4.2", normalizeImage("docker.io/goharbor/harbor-core:v2.4.2"))
 	assert.Equal(t, "k8s.gcr.io/ingress-nginx/controller:v0.48.1", normalizeImage("k8s.gcr.io/ingress-nginx/controller:v0.48.1"))
+	assert.Equal(t, "docker.io/library/docker:20.10.12-dind-alpine3.15", normalizeImage("docker:20.10.12-dind-alpine3.15"))
 }


### PR DESCRIPTION
We found that `docker:20.10.12-dind-alpine3.15` was not normalized to `docker.io/library/docker:20.10.12-dind-alpine3.15`
because of a logic error in `normalizeImage` which caused it to not match replacement rules and was thus ignored.

This fixes it and adds a regression test.