### PR TITLE
chore: fix backstage techdocs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ webhookConfig:
 You can find documentation for all available `webhookConfig` fields in
 [`config.sample.yaml`](config.sample.yaml). For more helm configuration options
 have a look into the [`values.yaml`
-defaults](charts/pod-image-swap-webhook/values.yaml).
+defaults](https://github.com/Bonial-International-GmbH/pod-image-swap-webhook/blob/main/charts/pod-image-swap-webhook/values.yaml).
 
 Finally use helm to install the webhook:
 

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -18,4 +18,4 @@ metadata:
 spec:
   type: service
   owner: ops
-  lifecycle: experimental
+  lifecycle: production

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,1 @@
+../README.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,2 +1,5 @@
 site_name: pod-image-swap-webhook
 site_description: 'A mutating webhook that patches Pod container images based on configuration rules.'
+
+nav:
+  - Home: index.md


### PR DESCRIPTION
- add `docs/index.md` as symlink to `README.md`
- make links in `README.md` absolute so they work both in backstage and GitHub
- update `lifecycle` to `production` since it's not experimental anymore