### PR TITLE
feat: add DaemonSet support to the helm chart

### DIFF
--- a/charts/pod-image-swap-webhook/Chart.yaml
+++ b/charts/pod-image-swap-webhook/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: pod-image-swap-webhook
 description: A webhook that replaces Pod images based on configuration values.
 type: application
-version: 0.0.3
+version: 0.1.0
 appVersion: "v0.0.3"

--- a/charts/pod-image-swap-webhook/templates/daemonset.yaml
+++ b/charts/pod-image-swap-webhook/templates/daemonset.yaml
@@ -1,15 +1,12 @@
-{{- if eq .Values.kind "Deployment" -}}
+{{- if eq .Values.kind "DaemonSet" -}}
 apiVersion: apps/v1
-kind: Deployment
+kind: DaemonSet
 metadata:
   name: {{ include "pod-image-swap-webhook.fullname" . }}
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "pod-image-swap-webhook.labels" . | nindent 4 }}
 spec:
-  {{- if not .Values.hpa.create }}
-  replicas: {{ .Values.replicaCount }}
-  {{- end }}
   selector:
     matchLabels:
       {{- include "pod-image-swap-webhook.selectorLabels" . | nindent 6 }}

--- a/charts/pod-image-swap-webhook/templates/hpa.yaml
+++ b/charts/pod-image-swap-webhook/templates/hpa.yaml
@@ -1,5 +1,5 @@
-{{- if .Values.hpa.create }}
-apiVersion: autoscaling/v2beta1
+{{- if and .Values.hpa.create (eq .Values.kind "Deployment") }}
+apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   name: {{ include "pod-image-swap-webhook.fullname" . }}
@@ -18,12 +18,16 @@ spec:
     - type: Resource
       resource:
         name: cpu
-        targetAverageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetCPUUtilizationPercentage }}
     {{- end }}
     {{- if .Values.hpa.targetMemoryUtilizationPercentage }}
     - type: Resource
       resource:
         name: memory
-        targetAverageUtilization: {{ .Values.hpa.targetMemoryUtilizationPercentage }}
+        target:
+          type: Utilization
+          averageUtilization: {{ .Values.hpa.targetMemoryUtilizationPercentage }}
     {{- end }}
 {{- end }}

--- a/charts/pod-image-swap-webhook/values.yaml
+++ b/charts/pod-image-swap-webhook/values.yaml
@@ -1,6 +1,9 @@
 # Default values for pod-image-swap-webhook.
 
-# Ignored if `hpa.create` is set to `true`.
+# Valid values are `Deployment` and `DaemonSet`.
+kind: Deployment
+
+# Ignored if `hpa.create` is set to `true` or if `kind` is `DaemonSet`.
 replicaCount: 2
 
 image:
@@ -45,6 +48,7 @@ resources: {}
   #   memory: 20Mi
 
 hpa:
+  # Ignored if `kind` is `DaemonSet`.
   create: true
   minReplicas: 2
   maxReplicas: 6


### PR DESCRIPTION
Adds the `kind` value which defaults to `Deployment` but can be set to `DaemonSet` if desired.

Replica and HPA configuration is ignored if `kind` is `DaemonSet`.

Furthermore this change updates the `apiVersion` for the `HorizontalPodAutoscaler` to `autoscaling/v2` since `autoscaling/v2beta1` is deprecated and removed in Kubernetes 1.25. This required some minor changes to the configuration schema.