### PR TITLE
feat: allow configuring priorityClassName in helm chart

### DIFF
--- a/charts/pod-image-swap-webhook/Chart.yaml
+++ b/charts/pod-image-swap-webhook/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: pod-image-swap-webhook
 description: A webhook that replaces Pod images based on configuration values.
 type: application
-version: 0.1.0
+version: 0.1.1
 appVersion: "v0.0.3"

--- a/charts/pod-image-swap-webhook/templates/_helpers.tpl
+++ b/charts/pod-image-swap-webhook/templates/_helpers.tpl
@@ -130,6 +130,9 @@ spec:
     - secret:
         secretName: {{ include "pod-image-swap-webhook.fullname" . }}
       name: certs
+  {{- with .Values.priorityClassName }}
+  priorityClassName: {{ . }}
+  {{- end }}
   {{- with .Values.nodeSelector }}
   nodeSelector:
     {{- toYaml . | nindent 4 }}

--- a/charts/pod-image-swap-webhook/values.yaml
+++ b/charts/pod-image-swap-webhook/values.yaml
@@ -59,6 +59,8 @@ podDisruptionBudget:
   create: true
   minAvailable: 1
 
+priorityClassName: ""
+
 nodeSelector: {}
 
 tolerations: []


### PR DESCRIPTION
Especially if running in `DaemonSet` mode, the webhook should receive a high priority class, e.g. `system-node-critical` to ensure that it can always be scheduled. This makes this configurable. By default, no priority class is assigned.