### PR TITLE
chore(deps): bump golang from 1.19 to 1.21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        go-version: [1.19.x]
+        go-version: [1.21.x]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.19.0-alpine3.16 as builder
+FROM golang:1.21.3-alpine3.18 as builder
 
 WORKDIR /src
 
@@ -17,7 +17,7 @@ COPY pkg/ pkg/
 
 RUN make build
 
-FROM alpine:3.16
+FROM alpine:3.18
 
 RUN apk --update --no-cache add ca-certificates
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/Bonial-International-GmbH/pod-image-swap-webhook
 
-go 1.19
+go 1.21
 
 require (
 	github.com/stretchr/testify v1.8.4


### PR DESCRIPTION
Required for upgrading `controller-runtime` to the latest version.