### PR TITLE
fix(mega-linter): remove GO_GOLANGCI_LINT_CLI_LINT_MODE

### DIFF
--- a/.mega-linter.yml
+++ b/.mega-linter.yml
@@ -5,5 +5,4 @@ DISABLE:
 DISABLE_LINTERS:
   - REPOSITORY_CHECKOV # It's annoyed by the helm chart in charts/
 GO_GOLANGCI_LINT_ARGUMENTS: --timeout=5m
-GO_GOLANGCI_LINT_CLI_LINT_MODE: project
 REPOSITORY_TRIVY_ARGUMENTS: --ignorefile .trivyignore.yaml


### PR DESCRIPTION
The key is not present in the schema anymore, causing the `v8r` linter to fail for all current PRs.