### PR TITLE
fix(github): skip uploading existing chart versions

### DIFF
--- a/.github/workflows/release-charts.yml
+++ b/.github/workflows/release-charts.yml
@@ -35,3 +35,5 @@ jobs:
         uses: helm/chart-releaser-action@v1.6.0
         env:
           CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+        with:
+          skip_existing: true


### PR DESCRIPTION
https://github.com/helm/chart-releaser-action?tab=readme-ov-file#inputs

The `release-charts` workflow run every time there is a change in `main`. Previously it would skip publishing the chart if there was no version change. With version 1.6.0 of the `chart-releaser-action` the behaviour changed and this is an error now:

https://github.com/Bonial-International-GmbH/pod-image-swap-webhook/actions/runs/9543210930/job/26299381418

To reinstate the desired behaviour, I set the `skip_existing` input to on the action.